### PR TITLE
Expose

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The `dataProvider` module allows data fetching from a url or from the initial da
 
 ###`dataProvider(component, url, options)`
 
-- `component` React component. Used to store and retrieve the data in a local variable to prevent useless calls on the first page load, and for caching.
+- `expose` String. The name under which the data will be available
 - `url` Url to call
 - `options` Object. Available options:
     - `once`: Removes the data from the local variable after use. This means the next time you call the same data it will fetch them remotely. Default to false.
@@ -132,7 +132,7 @@ import provider from 'react-collider/dataProvider'
 
 class Video extends React.Component {
     static fetchData(params) {
-        return provider(this, `https://api.dailymotion.com/video/${params.id}?fields=id,title`, {once: true})
+        return provider('video', `https://api.dailymotion.com/video/${params.id}?fields=id,title`, {once: true})
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -63,14 +63,17 @@ collider(routes)
 
 ### Components
 
-If your component must fetch some data before being rendered, use a `fetchData` static method. It must return a promise.
+If your component must fetch some data before being rendered, use a `fetchData` static method. It must return a promise. The component also has to have a `expose` static method to know under which name the data will be exposed. If no `expose` method is available, it will use the `displayName` of the component.
 
-The `fetchData` method will receive an argument being the params [from the router](http://rackt.github.io/react-router/#getting-the-url-parameters).
+The `fetchData` and `expose` methods will receive an argument being the params [from the router](http://rackt.github.io/react-router/#getting-the-url-parameters).
 
 Example of a simple component:
 
 ```javascript
 export default class Home extends React.Component {
+    static expose(params) {
+        return `home-user-${params.id}`
+    }
     static fetchData(params) {
         // returns a promise
         return getHomeData({userId: params.id})
@@ -112,8 +115,6 @@ export default class Home extends React.Component {
 }
 ```
 
-**Important:** If you're not using es6 to write your components, be sure to define the `displayName` of your components. This is necessary for the module to correctly return the data.
-
 ## Data Provider
 
 The `dataProvider` module allows data fetching from a url or from the initial data fetched server-side.
@@ -131,8 +132,11 @@ The `dataProvider` module allows data fetching from a url or from the initial da
 import provider from 'react-collider/dataProvider'
 
 class Video extends React.Component {
+    static expose() {
+        return 'video'
+    }
     static fetchData(params) {
-        return provider('video', `https://api.dailymotion.com/video/${params.id}?fields=id,title`, {once: true})
+        return provider(Video.expose(), `https://api.dailymotion.com/video/${params.id}?fields=id,title`, {once: true})
     }
 }
 ```

--- a/example/package.json
+++ b/example/package.json
@@ -20,7 +20,7 @@
     "json-stable-stringify": "^1.0.0",
     "node-jsx": "^0.12.4",
     "react": "^0.13.1",
-    "react-collider": "^1.8.7",
+    "react-collider": "dailymotion/react-collider#e8c3ea7695416aeefc0200c2f189fef2205baabb",
     "react-router": "^0.13.2",
     "reactify": "^1.1.0",
     "superagent": "^1.1.0"

--- a/example/src/components/home/home.js
+++ b/example/src/components/home/home.js
@@ -3,12 +3,12 @@ import VideoPreview from './../video/preview'
 import provider from 'react-collider/dataProvider'
 
 export default class Home extends React.Component {
-    static getIds() {
-        return 'x2mb4y5,+x2mb373,+x2mmd5u'
+    static expose() {
+        return 'Home'
     }
     static fetchData() {
-        var url = 'https://api.dailymotion.com/videos?fields=id,title,thumbnail_240_url&languages=en&ids=' + Home.getIds()
-        return provider(this, url, {once: true})
+        var url = 'https://api.dailymotion.com/videos?fields=id,title,thumbnail_240_url&languages=en&limit=5'
+        return provider(Home.expose(), url, {once: true})
     }
     componentWillMount() {
         this.getVideosList((data) => this.setState({videos: data}))

--- a/example/src/components/home/home.js
+++ b/example/src/components/home/home.js
@@ -7,35 +7,21 @@ export default class Home extends React.Component {
         return 'Home'
     }
     static fetchData() {
-        var url = 'https://api.dailymotion.com/videos?fields=id,title,thumbnail_240_url&languages=en&limit=5'
-        return provider(Home.expose(), url, {once: true})
-    }
-    componentWillMount() {
-        this.getVideosList((data) => this.setState({videos: data}))
+        var url = 'https://api.dailymotion.com/videos?fields=id,title,thumbnail_720_url&languages=en&limit=5&list=what-to-watch'
+        return provider(Home.expose(), url, {once: false})
     }
     getVideosList(cb) {
-        var videos = '',
-            i = 0
+        var i = 0
 
-        var data = this.props.data.Home
-
-        if (typeof data === 'string') {
-            data = JSON.parse(data)
-        }
-
-        if (data !== null && typeof data === 'object' && typeof data.list !== 'undefined') {
-            videos = data.list.map(function(video) {
-                return <VideoPreview key={i++} video={video} />
-            })
-        }
-
-        cb(videos)
+        return this.props.data.Home.list.map((video) => {
+            return <VideoPreview key={i++} video={video} />
+        })
     }
     render() {
         return (
             <div>
                 <h1>Videos</h1>
-                {this.state.videos}
+                {this.getVideosList()}
             </div>
         )
     }

--- a/example/src/components/layout/head/head.js
+++ b/example/src/components/layout/head/head.js
@@ -45,6 +45,7 @@ export default class Head extends React.Component {
                 <title>{this.state.title}</title>
                 {metas}
                 {links}
+                <meta charSet="utf-8" />
             </head>
         )
     }

--- a/example/src/components/layout/html.js
+++ b/example/src/components/layout/html.js
@@ -26,7 +26,7 @@ export default class Html extends React.Component {
                     <Header />
                     <div className="container">
                         <div className="row">
-                            <Sidebar className="col-lg-2" data={this.props.data.Sidebar} />
+                            <Sidebar className="col-lg-2" data={this.props.data.sidebar} />
                             <div className="col-lg-10">
                                 <RouteHandler data={this.props.data} />
                             </div>

--- a/example/src/components/layout/sidebar/sidebar.js
+++ b/example/src/components/layout/sidebar/sidebar.js
@@ -2,43 +2,29 @@ import React from 'react'
 import provider from 'react-collider/dataProvider'
 
 export default class Sidebar extends React.Component {
-    static getIds() {
-        return 'xlnf0t,+x1wd0c,+x1d6bdd'
+    static expose() {
+        return 'sidebar'
     }
     static fetchData() {
-        return provider(this, 'https://api.dailymotion.com/users?fields=avatar_240_url,username&ids=' + Sidebar.getIds())
-    }
-    componentWillMount() {
-        this.getUsersList((data) => this.setState({users: data}))
+        return provider(Sidebar.expose(), 'https://api.dailymotion.com/users?fields=avatar_240_url,username&limit=5&list=recommended', {once: false})
     }
     getUsersList(cb) {
-        var users = '',
-            i = 0
+        var i = 0
 
-        var data = this.props.data
-
-        if (typeof data === 'string') {
-            data = JSON.parse(data)
-        }
-
-        if (data !== null && typeof data === 'object' && typeof data.list !== 'undefined') {
-            users = data.list.map(function(user) {
-                return (
-                    <div className="row user" key={i++}>
-                        <img className="col-lg-5" src={user.avatar_240_url} width="100%" />
-                        <span className="col-lg-7">{user.username}</span>
-                    </div>
-                )
-            })
-        }
-
-        cb(users)
+        return this.props.data.list.map((user) => {
+            return (
+                <div className="row user" key={i++}>
+                    <img className="col-lg-5" src={user.avatar_240_url} width="100%" />
+                    <span className="col-lg-7">{user.username}</span>
+                </div>
+            )
+        })
     }
     render() {
         return (
             <div className={this.props.className}>
                 <h3>Users</h3>
-                {this.state.users}
+                {this.getUsersList()}
             </div>
         )
     }

--- a/example/src/components/player/player.js
+++ b/example/src/components/player/player.js
@@ -5,7 +5,7 @@ export default class Player extends React.Component {
         return (
             <div className="player">
                 <iframe
-                    src={'http://dailymotion.com/embed/video/' + this.props.id}
+                    src={`http://dailymotion.com/embed/video/${this.props.id}`}
                     width="960" height="540" />
             </div>
         )

--- a/example/src/components/video/preview.js
+++ b/example/src/components/video/preview.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {Link} from 'react-router'
 
 export default class VideoPreview extends React.Component {
     render() {
@@ -6,11 +7,15 @@ export default class VideoPreview extends React.Component {
             <div className="video-preview">
                 <div className="row">
                     <div className="col-sm-6">
-                        <img src={this.props.video.thumbnail_240_url} width="100%" />
+                        <Link to="video" params={{id: this.props.video.id}}>
+                            <img src={this.props.video.thumbnail_720_url} width="100%" />
+                        </Link>
                     </div>
                     <div className="col-sm-6">
                         <h3>
-                            {this.props.video.title}
+                            <Link to="video" params={{id: this.props.video.id}}>
+                                {this.props.video.title}
+                            </Link>
                         </h3>
                     </div>
                 </div>

--- a/example/src/components/video/video.js
+++ b/example/src/components/video/video.js
@@ -6,15 +6,18 @@ export default class Video extends React.Component {
     static getVideoId() {
         return 'x2dsjzl'
     }
+    static expose() {
+        return 'videoData'
+    }
     static fetchData() {
         var url = 'https://api.dailymotion.com/video/' + Video.getVideoId() + '?fields=id,title'
-        return provider(this, url)
+        return provider(Video.expose(), url)
     }
     componentWillMount() {
         this.setState({video: this.getVideo()})
     }
     getVideo() {
-        var data = this.props.data.Video
+        var data = this.props.data.videoData
 
         if (typeof data === 'string') {
             data = JSON.parse(data)
@@ -25,7 +28,7 @@ export default class Video extends React.Component {
     render() {
         return (
             <div>
-                <h1>Video</h1>
+                <h1>{this.getVideo().title}</h1>
                 <Player id={this.state.video.id} />
             </div>
         )

--- a/example/src/components/video/video.js
+++ b/example/src/components/video/video.js
@@ -3,33 +3,18 @@ import Player from './../player/player'
 import provider from 'react-collider/dataProvider'
 
 export default class Video extends React.Component {
-    static getVideoId() {
-        return 'x2dsjzl'
-    }
-    static expose() {
+    static expose(params) {
         return 'videoData'
     }
-    static fetchData() {
-        var url = 'https://api.dailymotion.com/video/' + Video.getVideoId() + '?fields=id,title'
+    static fetchData(params) {
+        var url = `https://api.dailymotion.com/video/${params.id}?fields=id,title`
         return provider(Video.expose(), url)
-    }
-    componentWillMount() {
-        this.setState({video: this.getVideo()})
-    }
-    getVideo() {
-        var data = this.props.data.videoData
-
-        if (typeof data === 'string') {
-            data = JSON.parse(data)
-        }
-
-        return data
     }
     render() {
         return (
             <div>
-                <h1>{this.getVideo().title}</h1>
-                <Player id={this.state.video.id} />
+                <h1>{this.props.data.videoData.title}</h1>
+                <Player id={this.props.data.videoData.id} />
             </div>
         )
     }

--- a/example/src/routing.js
+++ b/example/src/routing.js
@@ -11,7 +11,7 @@ var routes = (
     <Route handler={Html} path="/">
         <DefaultRoute handler={Home} />
         <Route name="home" handler={Home} path="/" />
-        <Route name="video" handler={Video} path="/video" />
+        <Route name="video" handler={Video} path="/video/:id" />
     </Route>
 )
 

--- a/lib/dataProvider.js
+++ b/lib/dataProvider.js
@@ -20,15 +20,14 @@ var defaultOptions = {
     set: false
 };
 
-function dataProvider(component, url, options) {
+function dataProvider(expose, url, options) {
     options = _merge.merge(defaultOptions, options);
-    var name = component.displayName || component.name;
 
     return new Promise(function (resolve) {
-        if (!options.forceFetch && typeof initialData === 'object' && typeof initialData[name] !== 'undefined') {
-            var data = initialData[name];
+        if (!options.forceFetch && typeof initialData === 'object' && typeof initialData[expose] !== 'undefined') {
+            var data = initialData[expose];
             if (options.once) {
-                initialData[name] = undefined;
+                initialData[expose] = undefined;
             }
             resolve(data);
         } else {
@@ -39,7 +38,7 @@ function dataProvider(component, url, options) {
                 } else {
                     if (options.set) {
                         initialData = initialData || {};
-                        initialData[name] = res.body;
+                        initialData[expose] = res.body;
                     }
 
                     resolve(res.body);

--- a/lib/defaultFetchHandler.js
+++ b/lib/defaultFetchHandler.js
@@ -17,7 +17,8 @@ function defaultFetchHandler(components, params) {
 
         components.forEach(function (component) {
             if (typeof component.fetchData === 'function') {
-                var name = component.displayName || component.name;
+                var displayName = component.displayName || component.name,
+                    name = typeof component.expose === 'function' ? component.expose(params) : displayName;
                 if (!_contains.contains(name)(components)) {
                     componentsName.push(name);
                     fetches.push(component.fetchData(params));

--- a/src/dataProvider.js
+++ b/src/dataProvider.js
@@ -3,7 +3,7 @@ import Promise from 'bluebird'
 import {merge} from 'ramda'
 
 const defaultOptions = {
-    once: false,
+    once: true,
     forceFetch: false,
     set: false
 }

--- a/src/dataProvider.js
+++ b/src/dataProvider.js
@@ -8,15 +8,14 @@ const defaultOptions = {
     set: false
 }
 
-export default function dataProvider(component, url, options) {
+export default function dataProvider(expose, url, options) {
     options = merge(defaultOptions, options)
-    var name = component.displayName || component.name
 
     return new Promise(function(resolve) {
-        if (!options.forceFetch && typeof initialData === 'object' && typeof initialData[name] !== 'undefined') {
-            var data = initialData[name]
+        if (!options.forceFetch && typeof initialData === 'object' && typeof initialData[expose] !== 'undefined') {
+            var data = initialData[expose]
             if (options.once) {
-                initialData[name] = undefined
+                initialData[expose] = undefined
             }
             resolve(data)
         }
@@ -32,7 +31,7 @@ export default function dataProvider(component, url, options) {
                 else {
                     if (options.set) {
                         initialData = initialData || {}
-                        initialData[name] = res.body
+                        initialData[expose] = res.body
                     }
 
                     resolve(res.body)

--- a/src/defaultFetchHandler.js
+++ b/src/defaultFetchHandler.js
@@ -8,7 +8,8 @@ export default function defaultFetchHandler(components, params) {
 
         components.forEach(function(component) {
             if (typeof component.fetchData === 'function') {
-                var name = component.displayName || component.name
+                var displayName = component.displayName || component.name,
+                    name = typeof component.expose === 'function' ? component.expose(params) : displayName
                 if (!contains(name)(components)) {
                     componentsName.push(name)
                     fetches.push(component.fetchData(params))

--- a/test/components/home-content.js
+++ b/test/components/home-content.js
@@ -6,6 +6,9 @@ var React = require('react'),
 var HomeContent = React.createClass({
     displayName: 'HomeContent',
     statics: {
+        expose: function() {
+            return 'home-content'
+        },
         fetchData: function() {
             return new Promise(function(resolve) {
                 fs.readFile(path.join(__dirname, 'fixtures.json'), 'utf-8', function(err, data) {

--- a/test/components/sidebar.js
+++ b/test/components/sidebar.js
@@ -4,8 +4,10 @@ var React = require('react'),
     Promise = require('bluebird')
 
 var Sidebar = React.createClass({
-    displayName: 'Sidebar',
     statics: {
+        expose: function() {
+            return 'sidebar'
+        },
         fetchData: function() {
             return new Promise(function(resolve) {
                 fs.readFile(path.join(__dirname, 'fixtures.json'), 'utf-8', function(err, data) {

--- a/test/components/video.js
+++ b/test/components/video.js
@@ -4,8 +4,10 @@ var React = require('react'),
     Promise = require('bluebird')
 
 var Video = React.createClass({
-    displayName: 'Video',
     statics: {
+        expose: function() {
+            return 'video'
+        },
         fetchData: function() {
             return new Promise(function(resolve) {
                 fs.readFile(path.join(__dirname, 'fixtures.json'), 'utf-8', function(err, data) {

--- a/test/dataProvider.js
+++ b/test/dataProvider.js
@@ -20,7 +20,7 @@ describe('Data Provider', function() {
     })
 
     it('should fetch data from a url', function(done) {
-        provider(Video, 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title').then(function(data) {
+        provider('video', 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title').then(function(data) {
             expect(data).to.be.an('object')
             expect(data.title).to.equal(videoData.title)
             done()
@@ -28,9 +28,9 @@ describe('Data Provider', function() {
     })
 
     it('should fetch data from local variable', function(done) {
-        global.initialData = {Video: localData}
+        global.initialData = {video: localData}
 
-        provider(Video, 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title').then(function(data) {
+        provider('video', 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title').then(function(data) {
             expect(data).to.be.an('object')
             expect(data.title).to.equal(localData.title)
             done()
@@ -38,12 +38,12 @@ describe('Data Provider', function() {
     })
 
     it('should fetch data from local variable without removing it', function(done) {
-        global.initialData = {Video: localData}
+        global.initialData = {video: localData}
 
-        provider(Video, 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title', {once: false}).then(function(data) {
+        provider('video', 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title', {once: false}).then(function(data) {
             expect(data.title).to.equal(localData.title)
 
-            provider(Video, 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title').then(function(data) {
+            provider('video', 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title').then(function(data) {
                 expect(data.title).to.equal(localData.title)
                 done()
             })
@@ -51,9 +51,9 @@ describe('Data Provider', function() {
     })
 
     it('should fetch data from local variable then remove it fetch from url', function(done) {
-        global.initialData = {Video: localData}
+        global.initialData = {video: localData}
 
-        provider(Video, 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title', {once: true}).then(function(data) {
+        provider('video', 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title', {once: true}).then(function(data) {
             expect(data.title).to.equal(localData.title)
 
             provider('Video', 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title').then(function(data) {
@@ -64,9 +64,9 @@ describe('Data Provider', function() {
     })
 
     it('should force fetching from the url even the local data exists', function(done) {
-        global.initialData = {Video: localData}
+        global.initialData = {video: localData}
 
-        provider(Video, 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title', {forceFetch: true}).then(function(data) {
+        provider('video', 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title', {forceFetch: true}).then(function(data) {
             expect(data.title).to.equal(videoData.title)
             done()
         })
@@ -75,10 +75,10 @@ describe('Data Provider', function() {
     it('should set the variable locally', function(done) {
         global.initialData = {}
 
-        provider(Video, 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title', {set: true}).then(function(data) {
+        provider('video', 'https://api.dailymotion.com/video/' + videoId + '?fields=id,title', {set: true}).then(function(data) {
             expect(data.title).to.equal(videoData.title)
 
-            provider(Video, 'https://api.dailymotion.com/video/' + otherId + '?fields=id,title').then(function(data) {
+            provider('video', 'https://api.dailymotion.com/video/' + otherId + '?fields=id,title').then(function(data) {
                 expect(data.title).to.equal(videoData.title)
                 done()
             })

--- a/test/reactCollider.js
+++ b/test/reactCollider.js
@@ -3,7 +3,7 @@ var expect    = require('chai').expect,
     Promise   = require('bluebird'),
     collider  = require('..')
 
-describe('Run Router', function() {
+describe('React Collider', function() {
     it('should export a function', function() {
         expect(collider).to.be.a('function')
     })
@@ -18,21 +18,21 @@ describe('Run Router', function() {
 
     it('should return an object with components as keys and data - Video', function(done) {
         collider(routes, '/', null, function(Handler, data) {
-            expect(data).to.have.all.keys('Sidebar', 'HomeContent')
+            expect(data).to.have.all.keys('sidebar', 'home-content')
             done()
         })
     })
 
     it('should return an object with components as keys and data - Home', function(done) {
         collider(routes, '/video', null, function(Handler, data) {
-            expect(data).to.have.all.keys('Sidebar', 'Video')
+            expect(data).to.have.all.keys('sidebar', 'video')
             done()
         })
     })
 
     it('should get the params', function(done) {
         collider(routes, '/user/1', null, function(Handler, data) {
-            expect(data).to.have.all.keys('Sidebar', 'User')
+            expect(data).to.have.all.keys('sidebar', 'User')
             expect(data.User.user).to.equal('1')
             done()
         })

--- a/test/server.js
+++ b/test/server.js
@@ -4,7 +4,7 @@ var expect   = require('chai').expect,
     collider = require('../server'),
     routes   = require('./routing')
 
-describe('React Collider', function() {
+describe('Server', function() {
     var server
 
     before(function() {


### PR DESCRIPTION
Instead of using the component `displayName` or class name, the default fetch handler must use an `expose` static method in order to be able to choose the name under which the data are available. This will help prevent possible conflicts if a component is used several times.
